### PR TITLE
feat: add --trace flag for event data saving

### DIFF
--- a/src/__tests__/unit/hook-processor.test.ts
+++ b/src/__tests__/unit/hook-processor.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../utils/logger.js", () => ({
   },
 }));
 
-describe("Hook Processor - Debug Flag", () => {
+describe("Hook Processor - Trace Flag", () => {
   let mockFileStorage: any;
   const mockSlackClient = {
     chat: {
@@ -75,7 +75,7 @@ describe("Hook Processor - Debug Flag", () => {
     };
   };
 
-  it("should save raw events when debug is true", async () => {
+  it("should save raw events when trace is true", async () => {
     const hookEvent = {
       hook_event_name: "UserPromptSubmit",
       session_id: "test-session",
@@ -90,7 +90,8 @@ describe("Hook Processor - Debug Flag", () => {
       slackClient: mockSlackClient,
       channel: "test-channel",
       dryRun: false,
-      debug: true,
+      debug: false,
+      trace: true,
       storageDir: "/test/storage",
     });
 
@@ -102,7 +103,7 @@ describe("Hook Processor - Debug Flag", () => {
     );
   });
 
-  it("should not save raw events when debug is false", async () => {
+  it("should not save raw events when trace is false", async () => {
     const hookEvent = {
       hook_event_name: "UserPromptSubmit",
       session_id: "test-session",
@@ -125,7 +126,7 @@ describe("Hook Processor - Debug Flag", () => {
     expect(mockFileStorage.appendEvent).not.toHaveBeenCalled();
   });
 
-  it("should not save raw events in dry-run mode when debug is false", async () => {
+  it("should not save raw events in dry-run mode when trace is false", async () => {
     const hookEvent = {
       hook_event_name: "UserPromptSubmit",
       session_id: "test-session",
@@ -148,7 +149,7 @@ describe("Hook Processor - Debug Flag", () => {
     expect(mockFileStorage.appendEvent).not.toHaveBeenCalled();
   });
 
-  it("should save raw events in dry-run mode when debug is true", async () => {
+  it("should save raw events in dry-run mode when trace is true", async () => {
     const hookEvent = {
       hook_event_name: "UserPromptSubmit",
       session_id: "test-session",
@@ -163,7 +164,8 @@ describe("Hook Processor - Debug Flag", () => {
       slackClient: null,
       channel: "test-channel",
       dryRun: true,
-      debug: true,
+      debug: false,
+      trace: true,
       storageDir: "/test/storage",
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ program
   .option("-t, --token <token>", "Slack bot token", process.env.SLACK_BOT_TOKEN)
   .option("-d, --debug", "Enable debug logging", false)
   .option("--dry-run", "Process messages without sending to Slack", false)
+  .option("--trace", "Save raw hook event data to file", false)
   .option(
     "--thread-timeout <seconds>",
     "Thread inactivity timeout in seconds",
@@ -80,6 +81,8 @@ program
           dryRun: options.dryRun,
           threadTimeoutSeconds,
           debug: options.debug,
+          trace: options.trace,
+          storageDir: createFileStorage().getStorageDir(),
         });
 
         logger.debug("Hook processing completed successfully");

--- a/src/hook-processor.ts
+++ b/src/hook-processor.ts
@@ -14,6 +14,7 @@ interface ProcessOptions {
   threadTimeoutSeconds?: number;
   storageDir?: string;
   debug: boolean;
+  trace?: boolean;
 }
 
 export async function processHookInput(options: ProcessOptions): Promise<void> {
@@ -24,6 +25,7 @@ export async function processHookInput(options: ProcessOptions): Promise<void> {
     threadTimeoutSeconds,
     storageDir,
     debug,
+    trace,
   } = options;
 
   return new Promise((resolve, reject) => {
@@ -53,8 +55,8 @@ export async function processHookInput(options: ProcessOptions): Promise<void> {
           sessionId: hookEvent.session_id,
         });
 
-        // Save raw event to storage in debug mode
-        if (debug && storageDir) {
+        // Save raw event to storage in trace mode
+        if (trace && storageDir) {
           try {
             const storage = createFileStorage({ storageDir });
             await storage.appendEvent(hookEvent.session_id, hookEvent);

--- a/src/utils/file-storage.ts
+++ b/src/utils/file-storage.ts
@@ -270,4 +270,5 @@ export const createFileStorage = (config: FileStorageConfig = {}) => ({
   cleanupOldSessions: (maxAgeMs: number) =>
     cleanupOldSessions(maxAgeMs, config),
   migrateOldFormat: () => migrateOldFormat(config),
+  getStorageDir: () => config.storageDir || DEFAULT_STORAGE_DIR,
 });


### PR DESCRIPTION
## Summary
- Add new `--trace` CLI option to save raw hook event data to file
- Separate event tracing functionality from debug logging

## Changes
- Add `--trace` flag to CLI that saves raw hook events to `~/.ccth/{session_id}/events.jsonl`
- Change event saving logic from `debug` flag to `trace` flag in hook processor
- Add `getStorageDir()` method to file storage for retrieving storage directory
- Update tests to reflect the new trace flag usage
- Keep `--debug` flag behavior unchanged (only controls log levels)

## Test plan
- [x] Run unit tests: `npm test -- hook-processor.test.ts`
- [x] Manual testing with `--trace` flag to verify event saving
- [x] Verify `--debug` flag still controls log levels correctly
- [ ] CI tests pass