### PR TITLE
fix: suppress dotenv injection message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { logger } from "./utils/logger.js";
 import { createFileStorage } from "./utils/file-storage.js";
 
 // Load environment variables
-config();
+config({ quiet: true });
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary
- Add `quiet: true` option to dotenv config to suppress the injection message

## Changes
- Update `config()` call to `config({ quiet: true })` in cli.ts

## Motivation
The dotenv injection message appears on every command execution, which adds unnecessary noise to the output. This change suppresses the message for cleaner CLI output.

## Test plan
- [x] Manual testing to verify the injection message is suppressed
- [ ] CI tests pass