### PR TITLE
Align pnpm setup with packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
       
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -57,8 +55,6 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "author": "Masato Kusaka",
   "license": "MIT",
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.32.1",
   "dependencies": {
     "@slack/web-api": "^7.9.3",
     "commander": "^14.0.0",


### PR DESCRIPTION
Summary

Update pnpm management so the root `package.json` is the single source of truth and the CI workflow no longer pins pnpm separately.

Changes

- Bump root `packageManager` to `pnpm@10.32.1`.
- Remove `with.version` from both `pnpm/action-setup` steps in `.github/workflows/ci.yml`.

Why

- Keeps pnpm versioning centralized in `package.json`.
- Avoids duplicated version pins between the package manifest and CI workflow.

Notes

- The workflow still uses `pnpm/action-setup@v4`; only the pnpm version pin was removed.
- No lockfile changes were required.

Testing

- `node -e "const pkg=require('./package.json'); if(pkg.packageManager!=='pnpm@10.32.1') throw new Error(pkg.packageManager); console.log(pkg.packageManager)"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"`
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm test`
- `pnpm run build`
